### PR TITLE
Fix type

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -1,3 +1,6 @@
+body {
+  font-family: Source Sans Pro, sans-serif;
+}
 .post-content code {
   font-family: Courier new, sans-serif monospace;
 }

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
 
 	<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
 
+  <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700' rel='stylesheet' type='text/css'>
 	<link rel="stylesheet" href="css/gumby.css">
 	<link rel="stylesheet" href="css/custom.css">
 

--- a/index.html
+++ b/index.html
@@ -119,7 +119,6 @@
 		      <ul>
 		      	<li>Daniel X O’Neil, Chair</li>
 		      	<li>Aneesh Chopra</li>
-		      	<li><s>Max Ogden</s> <a href="/2014/04/02/dat">now an employee!</a></li>
 		      </ul>
 
 		      <h4>Staff</h4>
@@ -128,8 +127,6 @@
 		      	<li>Max Ogden, <a href="http://dat-data.com/">Dat Project</a> Lead</li>
 				<li>Mathias Buus, Dat Project</li>
 				<li>Karissa McKelvey, Dat Project</li>
-				<li>Finn Pauls, Dat Project</li>
-				<li>Bruno Vieira, Dat Project</li>
 		      </ul>
 
 		    </div>


### PR DESCRIPTION
@waldoj this vastly improves the readability -- the type being used by default in gumby is hard to read on projectors and the like

Is  the usopendata menu kinda broken on mobile for you?
